### PR TITLE
[ADD] anuncioslumicolor: Add description column to report_delivery_document

### DIFF
--- a/anuncioslumicolor/__manifest__.py
+++ b/anuncioslumicolor/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://www.vauxoo.com",
     "license": "LGPL-3",
     "category": "Installer",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "depends": [
         "account_payment",
         "board",
@@ -39,6 +39,7 @@
         "reports/report_external_layouts.xml",
         "reports/report_picking.xml",
         "reports/report_saleorder_document.xml",
+        "reports/report_delivery_document_inherit.xml",
     ],
     "demo": [
         "demo/res_partner_demo.xml",

--- a/anuncioslumicolor/reports/report_delivery_document_inherit.xml
+++ b/anuncioslumicolor/reports/report_delivery_document_inherit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="report_delivery_document_inherit" inherit_id="stock.report_delivery_document" priority="100">
+        <xpath expr="//div/table[1]/tbody/t/t/td[1]" position="replace">
+            <td id="product_name"><span t-field="move.name"/></td>
+        </xpath>
+    </template>
+
+    <template id="report_delivery_document_inherit" inherit_id="stock.report_delivery_document" priority="100">
+        <xpath expr="//div/table[2]/tbody/t/tr/td[1]" position="replace">
+            <td id="product_name"><span t-field="bo_line.name"/></td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Issue
On the report of delivery it doesn't show the full description of the product

Implement
Was added a the full description to the report of report_delivery_document like the report of sale order, with the same typography